### PR TITLE
fix: giustificato paragrafi dei documenti interni, esterni e verbali

### DIFF
--- a/template/template.typ
+++ b/template/template.typ
@@ -41,6 +41,7 @@
     pagebreak()
 
     set align(left)
+    
 
     text("Changelog", weight: "bold")
 
@@ -54,7 +55,7 @@
     outline(title: "Indice", indent: true)
 
     pagebreak()
-
+    set par(justify: true)
     body
 }
 
@@ -71,7 +72,7 @@
     body
 ) = {
     documento(title: title, sommario: sommario, changelog: changelog, [])
-
+    set par(justify: true)
     set heading(numbering: "1.1")
     set page(numbering: "1")
     show link: underline
@@ -163,7 +164,7 @@
 
     set align(left)
     pagebreak()
-
+    set par(justify: true)
     body
 }
 


### PR DESCRIPTION
close #57 
Un paio di considerazioni:

1. ho messo la funzione di giustificazione in tutte e tre le funzioni perché se la metto solo in quella principale vengono giustificati solo i documenti e non i verbali;
2. Ho giustificato solo a partire dalla sezione 1 dei documenti;
3. Devo aggiungere 0.0.1 su tutti i documenti?