### PR TITLE
UC Visualizzazione blocchi configurati

### DIFF
--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -734,3 +734,70 @@
    3. viene visualizzato un messaggio d'errore.
 - *Post-condizioni*:
    - Viene segnalato all'utente che non è possibile connettersi al database.
+
+=== Visualizzazione blocchi configurati <visualizzazione-blocchi-configurati>
+#figure(
+    diagram(
+    debug: false,
+    node-stroke: 1pt,
+    edge-stroke: 1pt,
+    label-size: 8pt,
+    node-inset: 10pt,
+    node((0,0.25), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
+    edge(<user>, <a>),
+
+    node((2,0), align(center)[
+            @visualizzazione-blocchi-configurati
+            Visualizzazione blocchi configurati
+    ], shape: ellipse, name: <a>),
+
+    node((1.8,1), align(center)[
+            @avviso-servizi-non-collegati Avviso servizi non collegati
+    ], shape: ellipse, name: <b>),
+    edge(<b>, <a>, "--straight", [\<\<extend\>\>]),
+
+    node((2.6,0.4), align(center)[
+            Nessun servizio #linebreak() collegato
+    ], shape: rect, name: <le>),
+    node((1.89,0.5), align(center)[
+    ], shape: circle, name: <nf>, width: 1pt, height: 1pt),
+    edge(<le>, <nf>, "--"),
+    node(enclose: (<a>,<b>,<le>),
+        align(top + right)[Sistema],
+        width: 300pt,
+        height: 170pt,
+        snap: -1,
+        name: <group>)
+    ),
+    caption: [Visualizzazione blocchi configurati UC diagram.]
+) <visualizzazione-blocchi-configurati-diagram>
+
+- *Attori principali*:
+  - Utente autenticato.
+- *Scenario principale*:
+ - Utente autenticato:
+    1. Avvia la procedura di creazione di un nuovo workflow.
+ - Sistema:
+    1. Controlla che ci sia un account Google collegato.
+    2. Trova un account Google collegato.
+    3. Fa visualizzare i blocchi dei servizi di Google.
+- *Post-condizioni*:
+   - L'utente visualizza i blocchi configurati.
+- *Estensioni*:
+   - Avviso servizi non collegati.
+
+=== Avviso servizi non collegati 
+<avviso-servizi-non-collegati>
+
+- *Attori principali*:
+  - Utente autenticato.
+- *Scenario principale*:
+ - Utente autenticato:
+    1. Avvia la procedura di creazione di un nuovo workflow.
+ - Sistema:
+    1. Controlla che ci sia un account Google collegato.
+    2. Non trova un account Google collegato. 
+    3. Viene visualizzato un avviso.
+- *Post-condizioni*:
+   - Viene segnalato all'utente che non ha nessun account Google collegato.
+   - L'utente viene rediretto alla pagina per collegare l'account Google.

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -742,18 +742,18 @@
     node-stroke: 1pt,
     edge-stroke: 1pt,
     label-size: 8pt,
-    node-inset: 10pt,
+
     node((0,0.25), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
     edge(<user>, <a>),
 
     node((2,0), align(center)[
             @visualizzazione-blocchi-configurati
             Visualizzazione blocchi configurati
-    ], shape: ellipse, name: <a>),
+    ], shape: ellipse, name: <a>, inset: 10pt),
 
     node((1.8,1), align(center)[
             @avviso-servizi-non-collegati Avviso servizi non collegati
-    ], shape: ellipse, name: <b>),
+    ], shape: ellipse, name: <b>, inset: 10pt),
     edge(<b>, <a>, "--straight", [\<\<extend\>\>]),
 
     node((2.6,0.4), align(center)[
@@ -771,16 +771,17 @@
     ),
     caption: [Visualizzazione blocchi configurati UC diagram.]
 ) <visualizzazione-blocchi-configurati-diagram>
-
+- *Desrizione*:
+  - Questo caso d'uso descrive la funzionalità di visualizzazione dei blocchi configurati.
 - *Attori principali*:
   - Utente autenticato.
 - *Scenario principale*:
  - Utente autenticato:
     1. Avvia la procedura di creazione di un nuovo workflow.
  - Sistema:
-    1. Controlla che ci sia un account Google collegato.
-    2. Trova un account Google collegato.
-    3. Fa visualizzare i blocchi dei servizi di Google.
+    1. Controlla che ci siano dei servizi collegati;
+    2. Trova almeno un servizio collegato;
+    3. Fa visualizzare i blocchi che un servizio associato nella sezione dei blocchi configurati.
 - *Post-condizioni*:
    - L'utente visualizza i blocchi configurati.
 - *Estensioni*:
@@ -788,16 +789,17 @@
 
 === Avviso servizi non collegati 
 <avviso-servizi-non-collegati>
-
+- *Desrizione*:
+  - Questo caso d'uso descrive la visualizzazione di un avviso per notificare all'utente che non ha nessun account Google collegato ai servizi offerti dai blocchi.
 - *Attori principali*:
   - Utente autenticato.
 - *Scenario principale*:
  - Utente autenticato:
     1. Avvia la procedura di creazione di un nuovo workflow.
  - Sistema:
-    1. Controlla che ci sia un account Google collegato.
-    2. Non trova un account Google collegato. 
-    3. Viene visualizzato un avviso.
+   1. Controlla che ci siano dei servizi collegati;
+   2. Non trova nessun servizio collegato; 
+   3. Viene visualizzato un avviso.
 - *Post-condizioni*:
-   - Viene segnalato all'utente che non ha nessun account Google collegato.
-   - L'utente viene rediretto alla pagina per collegare l'account Google.
+   - Viene segnalato all'utente che non ha nessun servizio collegato;
+   - L'utente viene rediretto alla pagina per collegare i servizio.

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -790,7 +790,7 @@
 === Avviso servizi non collegati 
 <avviso-servizi-non-collegati>
 - *Desrizione*:
-  - Questo caso d'uso descrive la visualizzazione di un avviso per notificare all'utente che non ha nessun account Google collegato ai servizi offerti dai blocchi.
+  - Questo caso d'uso descrive la visualizzazione di un avviso per notificare all'utente che non ha nessun account collegato ai servizi offerti dai blocchi.
 - *Attori principali*:
   - Utente autenticato.
 - *Scenario principale*:
@@ -802,4 +802,4 @@
    3. Viene visualizzato un avviso.
 - *Post-condizioni*:
    - Viene segnalato all'utente che non ha nessun servizio collegato;
-   - L'utente viene rediretto alla pagina per collegare i servizio.
+   - L'utente viene rediretto alla pagina per collegare i servizi.

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -781,7 +781,7 @@
  - Sistema:
     1. Controlla che ci siano dei servizi collegati;
     2. Trova almeno un servizio collegato;
-    3. Fa visualizzare i blocchi che un servizio associato nella sezione dei blocchi configurati.
+    3. Fa visualizzare i blocchi che hanno un servizio associato nella sezione dei blocchi configurati.
 - *Post-condizioni*:
    - L'utente visualizza i blocchi configurati.
 - *Estensioni*:


### PR DESCRIPTION
close #89 
Controllare uc16 e uc17
L'idea è che l'utente quando si reca nella schermata di creazione di un nuovo workflow, visualizza solamente i blocchi disponibili ad essere utilizzati (se non collega l'account di Google non può utilizzare quei blocchi quindi manco glieli faccio vedere o al massimo glieli oscuro per fargli capire che non li può utilizzare)