### PR TITLE
UC blocco Gmail

### DIFF
--- a/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
@@ -4,6 +4,7 @@
   title: "Analisi dei requisiti",
   sommario: "Documento di Analisi dei requisiti.",
   changelog: (
+    "0.2.15", "20/12/2024", "Aggiunta use case per visualizzazione funzionalità del blocco Gmail", team.M, team.S,
     "0.2.14", "18/12/2024", "Refactoring di alcuni use case", team.M, team.L,
     "0.2.13", "18/12/2024", "Aggiunta use case per visualizzazione blocchi configurati (e correlati)", team.M, team.S,
     "0.2.12", "17/12/2024", "Aggiunta sezione obiettivi e attori casi d'uso", team.A, team.L,

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -793,6 +793,6 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
     1. fa visualizzare all'utente una breve descrizione del blocco Gmail;
     2. fa visualizzare la lista delle funzioni disponibili: ricerca di una mail, ottenere una specifica mail, creazione di una bozza.
 - *Pre-condizioni*:
-    - L'utente ha collegato l'account di Google per utilizzare il blocco Gmail.
+    - L'utente ha associato l'account di Google collegato ai servizi offerti dai blocchi.
 - *Post-condizioni*:
    - L'utente visualizza una breve descrizione e le funzionalità offerte dal blocco Gmail.

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -765,12 +765,13 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
     edge-stroke: 1pt,
     label-size: 8pt,
     node-inset: 10pt,
+    node-shape: ellipse,
     node((0,0), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
     edge(<user>, <a>),
 
     node((2,0), align(center)[
             @funzionalità-blocco-gmail Visualizzazione funzioni blocco Gmail
-    ], shape: ellipse, name: <a>),
+    ], name: <a>),
 
     node(enclose: (<a>,),
         align(top + right)[Sistema],

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -795,4 +795,4 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
 - *Pre-condizioni*:
     - L'utente ha collegato l'account di Google per utilizzare il blocco Gmail.
 - *Post-condizioni*:
-   - L'utente visualizza una breve descrizione e le funzionalità offerte del blocco Gmail.
+   - L'utente visualizza una breve descrizione e le funzionalità offerte dal blocco Gmail.

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -756,3 +756,43 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
    3. viene visualizzato un messaggio d'errore.
 - *Post-condizioni*:
    - Viene segnalato all'utente che non è possibile connettersi al database.
+
+=== Visualizzazione funzioni del blocco Gmail <funzionalità-blocco-gmail>
+#figure(
+    diagram(
+    debug: false,
+    node-stroke: 1pt,
+    edge-stroke: 1pt,
+    label-size: 8pt,
+    node-inset: 10pt,
+    node((0,0), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
+    edge(<user>, <a>),
+
+    node((2,0), align(center)[
+            @funzionalità-blocco-gmail Visualizzazione funzioni blocco Gmail
+    ], shape: ellipse, name: <a>),
+
+    node(enclose: (<a>,),
+        align(top + right)[Sistema],
+        width: 150pt,
+        height: 150pt,
+        snap: -1,
+        name: <group>)
+    ),
+    caption: [Visualizzazione funzioni del blocco Gmail UC diagram.]
+) <visualizzazione-funzioni-blocco-gmail-diagram>
+- *Descrizione*
+  - Questo caso d'uso descrive la visualizzazione delle funzioni del blocco Gmail.
+- *Attori principali*:
+  - Utente autenticato.
+- *Scenario principale*:
+ - Utente autenticato:
+    1. clicca sul blocco Gmail;
+    2. visualizza le funzioni disponibili.
+ - Sistema:
+    1. fa visualizzare all'utente una breve descrizione del blocco Gmail;
+    2. fa visualizzare la lista delle funzioni disponibili: ricerca di una mail, ottenere una specifica mail, creazione di una bozza.
+- *Pre-condizioni*:
+    - L'utente ha collegato l'account di Google per utilizzare il blocco Gmail.
+- *Post-condizioni*:
+   - L'utente visualizza una breve descrizione e le funzionalità offerte del blocco Gmail.


### PR DESCRIPTION
close #142 
Controllare uc17.
L'utente nonostante possa scrivere quello che gli pare negli archi deve sapere quali sono le funzionalità che il blocco Gmail offre. Inoltre in questo esprimiamo nei requisiti cosa ci si aspetta per il blocco Gmail anche per quanto riguarda le API da dare in pasto all'agente.