### PR TITLE
Fix UC modifica

### DIFF
--- a/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
@@ -5,6 +5,7 @@
   title: "Analisi dei requisiti",
   sommario: "Documento di Analisi dei requisiti.",
   changelog: (
+    "0.13.1", "5/1/2024", "Fix use case per la modifica di un workflow", team.C, team.M,
     "0.13.0", "29/12/2024", "Aggiunti use case per la modifica di un workflow", team.C, team.M,
     "0.12.0", "29/12/2024", "Aggiunto use case esecuzione workflow da parte dell'agente", team.C, team.L,
     "0.11.1", "23/12/2024", "Fix use case creazione workflow", team.C, team.M,

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -1116,6 +1116,8 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
  - Sistema:
    1. non trova nessun servizio collegato; 
    2. mostra un avviso.
+- *Pre-condizioni*:
+  - L'utente non ha collegato alcun servizio esterno per l'uso dei blocchi.
 - *Post-condizioni*:
    - Viene segnalato all'utente che non ha nessun servizio collegato;
    - L'utente viene rediretto alla pagina per collegare i servizi.

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -790,106 +790,6 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
 - *Post-condizioni*:
    - Viene creato il workflow vuoto.
 
-=== Entrata modalità modifica <modifica-workflow>
-#figure(
-    diagram(
-    debug: false,
-    node-stroke: 1pt,
-    edge-stroke: 1pt,
-    label-size: 8pt,
-    node-inset: 10pt,
-    node-shape: ellipse,
-    node((0,0.3), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
-    edge(<user>, <a>),
-
-    node((1.5,0), align(center)[
-            @modifica-workflow Entrata modalità modifica
-    ], name: <a>),
-    
-    node((2,0.5), align(center)[
-        @visualizzazione-blocchi-configurati
-        Visualizzazione blocchi configurati
-    ], name: <b>),
-    edge(<a>, <b>, "--straight", [\<\<include\>\>]),
-
-    node((1.8,1), align(center)[
-            @avviso-servizi-non-collegati Avviso servizi non collegati
-    ], name: <c>),
-    edge(<c>, <b>, "--straight", [\<\<extend\>\>]),
-
-    node((0.9,0.7), align(center)[
-            Nessun servizio #linebreak() collegato
-    ], shape: rect, name: <le>),
-    node((1.89,0.8), align(center)[
-    ], name: <nf>, width: 1pt, height: 1pt),
-    edge(<le>, <nf>, "--"),
-
-    node(enclose: (<a>,<b>,<c>,<le>),
-        align(top + right)[Sistema],
-        width: 150pt,
-        height: 150pt,
-        snap: -1,
-        name: <group>)
-    ),
-    caption: [Entrata modalità modifica UC diagram.]
-) <modifica-workflow-diagram>
-
-- *Descrizione*:
-  - Questo caso d'uso descrive la procedura per entrare in modalità di modifica di un workflow.
-- *Attori principali*:
-  - Utente autenticato.
-- *Scenario principale*:
- - Utente autenticato:
-   1. seleziona il workflow da modificare;
-   2. si ritrova in una nuova schermata in cui viene visualizzato il workflow;
-   3. seleziona l'opzione di modifica del workflow;
-   4. visualizza anche i blocchi disponibili (@visualizzazione-blocchi-configurati).
- - Sistema:
-   1. mostra il workflow con l'opzione di modifica all'utente;
-   2. avvia la modifica del workflow;
-   3. mostra i blocchi configurati disponibili (@visualizzazione-blocchi-configurati).
-- *Pre-condizioni*:
-   - L'utente ha creato un workflow.
-- *Post-condizioni*:
-   - Viene avviata la modifica del workflow selezionato dall'utente.
-   
-==== Visualizzazione blocchi configurati <visualizzazione-blocchi-configurati>
-
-- *Descrizione*:
-  - Questo caso d'uso descrive la funzionalità di visualizzazione dei blocchi configurati.
-- *Attori principali*:
-  - Utente autenticato.
-- *Scenario principale*:
- - Utente autenticato:
-    1. visualizza i blocchi configurati.
- - Sistema:
-    1. verifica quali sono i servizi associati;
-    2. mostra i blocchi che hanno un servizio associato nella sezione dei blocchi configurati.
-- *Pre-condizioni*:
-   - L'utente ha collegato almeno un account esterno per poter utilizzare i blocchi ad esso associati.
-- *Post-condizioni*:
-   - L'utente visualizza i blocchi configurati.
-- *Estensioni*:
-   - Avviso servizi non collegati (@avviso-servizi-non-collegati).
-
-=== Avviso servizi non collegati 
-<avviso-servizi-non-collegati>
-- *Descrizione*:
-  - Questo caso d'uso descrive la visualizzazione di un avviso per notificare all'utente che non ha nessun account collegato ai servizi offerti dai blocchi.
-- *Attori principali*:
-  - Utente autenticato.
-- *Scenario principale*:
- - Utente autenticato:
-    1. visualizza un avviso che segnala l'assenza di servizi collegati.
- - Sistema:
-   1. non trova nessun servizio collegato; 
-   2. mostra un avviso.
-- *Pre-condizioni*:
-   - L'utente non ha collegato nessun account esterno per utilizzare i blocchi ad esso associati.
-- *Post-condizioni*:
-   - Viene segnalato all'utente che non ha nessun servizio collegato;
-   - L'utente viene rediretto alla pagina per collegare i servizi.
-
 === Aggiunta di un blocco <aggiunta-blocco>
 #figure(
     diagram(
@@ -922,15 +822,15 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
   - Utente autenticato.
 - *Scenario principale*:
  - Utente autenticato:
-   1. aggiunge un blocco di automazione (tra quelli disponibili) trascinandolo nell'area drag and drop.
+   1. aggiunge un blocco di automazione (tra quelli configurati) trascinandolo nell'area drag and drop.
  - Sistema:
-   1. mostra all'utente i blocchi disponibili (@visualizzazione-blocchi-configurati);
    2. gestisce l'input dell'utente;
    3. aggiorna il workflow.
 - *Pre-condizioni*:
-   - L'utente è entrato in modalità di modifica (@modifica-workflow).
+   - L'utente ha creato almeno un workflow;
+   - L'utente sta modificando il workflow.
 - *Post-condizioni*:
-   - Viene aggiunto il blocco scelto dall'utente al workflow.
+   - Viene aggiunto al workflow il blocco scelto dall'utente.
 
 === Eliminazione di un blocco <eliminazione-blocco>
 #figure(
@@ -970,8 +870,8 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
    1. gestisce gli input dell'utente;
    2. aggiorna il workflow.
 - *Pre-condizioni*:
-   - Il workflow ha almeno un blocco;
-   - L'utente è entrato in modalità di modifica (@modifica-workflow).
+   - L'utente ha creato un workflow con almeno un blocco;
+   - L'utente sta modificando il workflow.
 - *Post-condizioni*:
    - Viene eliminato un blocco dal workflow.
 
@@ -1013,9 +913,9 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
    1. gestisce l'input dell'utente;
    2. aggiorna il workflow.
 - *Pre-condizioni*:
-   - Il workflow ha almeno due blocchi;
+   - L'utente ha creato un workflow con almeno due blocchi;
    - I blocchi da collegare sono scollegati tra loro;
-   - L'utente è entrato in modalità di modifica (@modifica-workflow).
+   - L'utente sta modificando il workflow.
 - *Post-condizioni*:
    - Viene creato un arco orientato tra i due blocchi selezionati dall'utente.
 
@@ -1057,9 +957,9 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
    1. gestisce l'input dell'utente;
    2. aggiorna il workflow.
 - *Pre-condizioni*:
-   - Il workflow ha almeno due blocchi;
+   - L'utente ha creato un workflow con almeno due blocchi;
    - I blocchi da scollegare sono collegati tra loro;
-   - L'utente è entrato in modalità di modifica (@modifica-workflow).
+   - L'utente sta modificando il workflow.
 - *Post-condizioni*:
    - Viene eliminato l'arco orientato tra i due blocchi selezionati dall'utente.
 
@@ -1101,8 +1001,8 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
    1. gestisce l'input dell'utente;
    2. aggiorna il workflow.
 - *Pre-condizioni*:
-   - Il workflow ha almeno due blocchi collegati tramite un arco che non specifica alcuna descrizione;
-   - L'utente è entrato in modalità di modifica (@modifica-workflow).
+   - L'utente ha creato un workflow con almeno due blocchi collegati tramite un arco che non specifica alcuna descrizione;
+   - L'utente sta modificando il workflow.
 - *Post-condizioni*:
    - Viene aggiunta la descrizione dell'automazione relativa all'arco selezionato dall'utente.
 
@@ -1144,12 +1044,13 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
    1. gestisce gli input dell'utente;
    2. aggiorna il workflow.
 - *Pre-condizioni*:
-   - È presente una descrizione in almeno un arco orientato del workflow;
-   - L'utente è entrato in modalità di modifica (@modifica-workflow).
+   - L'utente ha creato un workflow con una descrizione in almeno un arco orientato;
+   - L'utente sta modificando il workflow.
 - *Post-condizioni*:
    - Viene modificata la descrizione dell'automazione relativa all'arco selezionato dall'utente.
 
-=== Uscita modalità modifica <stop-modifica-workflow>
+=== Visualizzazione blocchi configurati <visualizzazione-blocchi-configurati>
+
 #figure(
     diagram(
     debug: false,
@@ -1158,38 +1059,70 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
     label-size: 8pt,
     node-inset: 10pt,
     node-shape: ellipse,
-    node((0,0), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
-    edge(<user>, <a>),
+    node((0,0.3), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
+    edge(<user>, <b>),
+    
+    node((1.4,0.3), align(center)[
+        @visualizzazione-blocchi-configurati
+        Visualizzazione blocchi configurati
+    ], name: <b>),
 
-    node((2,0), align(center)[
-            @stop-modifica-workflow Uscita modalità modifica
-    ], name: <a>),
+    node((1.8,1), align(center)[
+            @avviso-servizi-non-collegati Avviso servizi non collegati
+    ], name: <c>),
+    edge(<c>, <b>, "--straight", [\<\<extend\>\>]),
 
-    node(enclose: (<a>,),
+    node((0.9,0.7), align(center)[
+            Nessun servizio #linebreak() collegato
+    ], shape: rect, name: <le>),
+    node((1.63,0.8), align(center)[
+    ], name: <nf>, width: 1pt, height: 1pt),
+    edge(<le>, <nf>, "--"),
+
+    node(enclose: (<b>,<c>,<le>),
         align(top + right)[Sistema],
         width: 150pt,
         height: 150pt,
         snap: -1,
         name: <group>)
     ),
-    caption: [Uscita modalità modifica UC diagram.]
-) <stop-modifica-workflow-diagram>
+    caption: [Visualizzazione blocchi configurati UC diagram.]
+) <visualizzazione-blocchi-configurati-diagram>
 
 - *Descrizione*:
-  - Questo caso d'uso descrive la procedura per uscire dalla modalità di modifica di un workflow.
+  - Questo caso d'uso descrive la funzionalità di visualizzazione dei blocchi configurati.
 - *Attori principali*:
   - Utente autenticato.
 - *Scenario principale*:
  - Utente autenticato:
-   1. termina la modifica del workflow;
-   2. seleziona l'opzione per uscire dalla modalità di modifica.
+    1. visualizza i blocchi configurati.
  - Sistema:
-   1. esce dalla modalità di modifica;
-   2. mostra la schermata con tutti i workflow.
+    1. verifica quali sono i servizi associati;
+    2. mostra i blocchi che hanno un servizio associato.
 - *Pre-condizioni*:
-   - L'utente è entrato in modalità di modifica (@modifica-workflow).
+   - L'utente ha collegato almeno un account esterno per poter utilizzare i blocchi ad esso associati.
 - *Post-condizioni*:
-   - Viene terminata la modifica del workflow selezionato dall'utente.
+   - L'utente visualizza i blocchi configurati.
+- *Estensioni*:
+   - Avviso servizi non collegati (@avviso-servizi-non-collegati).
+
+=== Avviso servizi non collegati 
+<avviso-servizi-non-collegati>
+- *Descrizione*:
+  - Questo caso d'uso descrive la visualizzazione di un avviso per notificare all'utente che non ha nessun account collegato ai servizi offerti dai blocchi.
+- *Attori principali*:
+  - Utente autenticato.
+- *Scenario principale*:
+ - Utente autenticato:
+    1. visualizza un avviso che segnala l'assenza di servizi collegati.
+ - Sistema:
+   1. non trova nessun servizio collegato; 
+   2. mostra un avviso.
+- *Pre-condizioni*:
+   - L'utente non ha collegato nessun account esterno per utilizzare i blocchi ad esso associati.
+- *Post-condizioni*:
+   - Viene segnalato all'utente che non ha nessun servizio collegato;
+   - L'utente viene rediretto alla pagina per collegare i servizi.
 
 === Salvataggio workflow <salvataggio-workflow>
 #figure(

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -1099,8 +1099,6 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
  - Sistema:
     1. verifica quali sono i servizi associati;
     2. mostra i blocchi che hanno un servizio associato.
-- *Pre-condizioni*:
-   - L'utente ha collegato almeno un account esterno per poter utilizzare i blocchi ad esso associati.
 - *Post-condizioni*:
    - L'utente visualizza i blocchi configurati.
 - *Estensioni*:
@@ -1118,8 +1116,6 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
  - Sistema:
    1. non trova nessun servizio collegato; 
    2. mostra un avviso.
-- *Pre-condizioni*:
-   - L'utente non ha collegato nessun account esterno per utilizzare i blocchi ad esso associati.
 - *Post-condizioni*:
    - Viene segnalato all'utente che non ha nessun servizio collegato;
    - L'utente viene rediretto alla pagina per collegare i servizi.


### PR DESCRIPTION
close #174 

cari verificatori, è stato deciso di tenere gli UC più atomici senza andare a fare collegamenti 'non naturali' tra loro (per non naturali si intende con include, estensioni e generalizzazioni). Ho quindi tolto entrata e uscita dalla modalità di modifica, resa atomica la visualizzazione dei blocchi configurati e sistemato i vari UC di gestione degli input dell'utente. 

as always lascio a voi il changelog