### PR TITLE
UC blocco pastebin

### DIFF
--- a/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
@@ -5,6 +5,7 @@
   title: "Analisi dei requisiti",
   sommario: "Documento di Analisi dei requisiti.",
   changelog: (
+    "0.15.0", "7/1/2024", "Aggiunto use case per visualizzazione funzionalità del blocco Pastebin", team.C, team.L,
     "0.14.0", "5/1/2024", "Aggiunto use case visualizzazione workflow", team.C, team.M,
     "0.13.1", "5/1/2024", "Fix use case per la modifica di un workflow", team.C, team.M,
     "0.13.0", "29/12/2024", "Aggiunti use case per la modifica di un workflow", team.C, team.M,

--- a/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ
@@ -1265,6 +1265,44 @@ tra il sistema e i servizi esterni, garantendo così una comprensione precisa de
 - *Post-condizioni*:
    - L'utente visualizza una breve descrizione e le funzionalità offerte dal blocco Gmail.  
 
+=== Visualizzazione funzioni del blocco Pastebin <funzionalità-blocco-pastebin>
+#figure(
+    diagram(
+    debug: false,
+    node-stroke: 1pt,
+    edge-stroke: 1pt,
+    label-size: 8pt,
+    node-inset: 10pt,
+    node-shape: ellipse,
+    node((0,0), [#image("../assets/actor.jpg") Utente autenticato], stroke: 0pt, name: <user>),
+    edge(<user>, <a>),
+
+    node((2,0), align(center)[
+            @funzionalità-blocco-pastebin Visualizzazione funzioni blocco Pastebin
+    ], name: <a>),
+
+    node(enclose: (<a>,),
+        align(top + right)[Sistema],
+        width: 150pt,
+        height: 150pt,
+        snap: -1,
+        name: <group>)
+    ),
+    caption: [Visualizzazione funzioni del blocco Pastebin UC diagram.]
+) <visualizzazione-funzionali-blocco-pastebin-diagram>
+- *Descrizione*:
+  - Questo caso d'uso descrive la visualizzazione delle funzioni del blocco Pastebin.
+- *Attori principali*:
+  - Utente autenticato.
+- *Scenario principale*:
+ - Utente autenticato:
+    1. clicca sul blocco Pastebin;
+    2. visualizza le funzioni disponibili.
+ - Sistema:
+    1. fa visualizzare all'utente una breve descrizione del blocco Pastebin;
+    2. fa visualizzare la lista delle funzioni disponibili: creare e scrivere su un documento.
+- *Post-condizioni*:
+   - L'utente visualizza una breve descrizione e le funzionalità offerte dal blocco Pastebin.  
 
 === Logout <logout>
 #figure(


### PR DESCRIPTION
close #150 

cari verificatori, ho aggiunto l'UC per pastebin che è andato a sostituire google docs. le funzionalità sono quelle indicatemi da giuseppe. non ho messo precondizione perchè da come ho capito non serve loggarsi o associare qualcosa in particolare con pastebin (a differenza del blocco gmail che serve per forza l'account). 

lascio a voi il changelog