### PR TITLE
Tabella requisiti di vincolo

### DIFF
--- a/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/analisi-dei-requisiti.typ
@@ -5,6 +5,7 @@
   title: "Analisi dei requisiti",
   sommario: "Documento di Analisi dei requisiti.",
   changelog: (
+    "0.20.0", "20/01/2025", "Aggiunti requisiti di vincolo", team.T, ";;;",
     "0.19.0", "18/01/2025", "Aggiunti requisiti di qualità", team.T, team.C,
     "0.18.1", "16/01/2025", "Aggiunto campo descrizione nella struttura dei casi d'uso e su UC3, UC4.", team.T, team.G,
     "0.18.0", "12/01/2025", "Aggiornamento tabella requisiti funzionali", team.A, team.M,

--- a/RTB/documenti_esterni/analisi_requisiti/include/requisiti.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/requisiti.typ
@@ -13,6 +13,8 @@
 #figure(
     table(
         columns: (1fr, 5fr, 2fr),
+        fill: (x, y) => if (y==0) { rgb("#f16610") } else { if calc.even(y) { gray.lighten(50%)} else { white }}, 
+        inset: 10pt,
         table.header([*Codice*], [*Descrizione*], [*Fonti*]),
         align: horizon + center,
         [FMR 1], [L'utente deve poter effettuare il login], 
@@ -60,6 +62,8 @@ Si dividono in:
 #figure(
     table(
         columns: (1fr, 5fr, 2fr),
+        fill: (x, y) => if (y==0) { rgb("#f16610") } else { if calc.even(y) { gray.lighten(50%)} else { white }}, 
+        inset: 10pt, 
         table.header([*Codice*], [*Descrizione*], [*Fonti*]),
         align: horizon + center,
         [QMR 1],[Documentare le criticità e i limiti delle soluzioni individuate],[Capitolato],
@@ -86,10 +90,12 @@ I requisiti di vincolo rappresentano delle restrizioni o dei limiti che il siste
 #figure(
     table(
         columns: (1fr, 5fr, 2fr),
+        fill: (x, y) => if (y==0) { rgb("#f16610") } else { if calc.even(y) { gray.lighten(50%)} else { white }}, 
+        inset: 10pt, 
         table.header([*Codice*], [*Descrizione*], [*Fonti*]),
         align: horizon + center,
         [CMR 1],[Il prodotto deve prevedere almeno tre blocchi],[Capitolato],
-        [CDR 1], [Il prodotto deve essere facilmente trasferibile sulla piattaforma #glossario[Docker]], [Capitolato, Riunione col proponente],
+        [CDR 1], [Il prodotto deve essere sviluppato in container #glossario[Docker] così il deploy su vari ambienti cloud (ad esempio #glossario[AWS])], [Capitolato, Riunione col proponente],
         [CMR 2],[Le parti del sistema devono comunicare tra di loro attraverso #glossario[API] che usano il protocollo HTTP],[Decisione interna]
     ),
     caption: [Tabella dei requisiti di vincolo.]

--- a/RTB/documenti_esterni/analisi_requisiti/include/requisiti.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/requisiti.typ
@@ -53,7 +53,7 @@
 I requisiti di #glossario[qualità] rappresentano come il sistema deve essere per soddisfare i requisiti dello stakeholder.\
 Si dividono in:
 - QMR (Qualitative Mandatory Requirement);
-    - irrinunciabile per qualcuno degli stakeholder.
+    - irrinunciabili per qualcuno degli stakeholder.
 - QDR (Qualitative Desirable Requirement);
     - non strettamente necessari ma a valore aggiunto riconoscibile.
 #set par (justify: false)
@@ -64,21 +64,36 @@ Si dividono in:
         align: horizon + center,
         [QMR 1],[Documentare le criticità e i limiti delle soluzioni individuate],[Capitolato],
         [QMR 2], [Dotarsi di un design modulare per agevolare la creazione di nuovi blocchi],[Capitolato],
-        [QDR 1], [Il prodotto deve essere facilmente trasferibile su #glossario[AWS]], [Capitolato, Riunione col proponente],
         [QMR 3],[Documentare i bug presenti],[Capitolato],
         [QMR 4],[Fornire il codice sorgente del prodotto attraverso un sistema di versionamento.],[Capitolato],
         [QMR 5],[Copertura dei #glossario[test di unità] pari ad almeno il 70% del codice prodotto],[Capitolato],
         [QMR 6],[Documentare i casi d'uso],[Capitolato],
         [QMR 7],[Documentare le classi attraverso #glossario[diagrammi UML]],[Capitolato],
         [QMR 8],[Rispettare quanto scritto nel documento "Norme di progetto" durante lo sviluppo del prodotto e della documentazione],[Norme di progetto],
-        [QDR 2],[Le #glossario[API] devono essere documentate in formato #glossario[Swagger]],[Formazione col proponente],
+        [QDR 1],[Le #glossario[API] devono essere documentate in formato #glossario[Swagger]],[Formazione col proponente],
         [QMR 10],[La documentazione deve rispettare le metriche descritte nel #glossario[piano di qualifica]],[Piano di qualifica §2.2],
-        [QDR 3],[Il codice TypeScript deve essere formattato secondo le regole #glossario[ESLint]],[Decisione interna]
+        [QDR 2],[Il codice TypeScript deve essere formattato secondo le regole #glossario[ESLint]],[Decisione interna]
     ),
     caption: [Tabella dei requisiti di qualità.]
 )<tabella-requisiti-di-qualita>
 == Requisiti di vincolo
-
+I requisiti di vincolo rappresentano delle restrizioni o dei limiti che il sistema deve rispettare.
+- CMR (Constraint Mandatory Requirement)
+    - irrinunciabili per qualcuno degli stakeholder.
+- CDR (Constraint Desirable Requirement)
+    - non strettamente necessari ma a valore aggiunto riconoscibile.
+#set par (justify: false)
+#figure(
+    table(
+        columns: (1fr, 5fr, 2fr),
+        table.header([*Codice*], [*Descrizione*], [*Fonti*]),
+        align: horizon + center,
+        [CMR 1],[Il prodotto deve prevedere almeno tre blocchi],[Capitolato],
+        [CDR 1], [Il prodotto deve essere facilmente trasferibile sulla piattaforma #glossario[Docker]], [Capitolato, Riunione col proponente],
+        [CMR 2],[Le parti del sistema devono comunicare tra di loro attraverso #glossario[API] che usano il protocollo HTTP],[Decisione interna]
+    ),
+    caption: [Tabella dei requisiti di vincolo.]
+)<tabella-requisiti-di-vincolo>
 == Tracciamento
 
 == Riepilogo

--- a/RTB/documenti_esterni/analisi_requisiti/include/requisiti.typ
+++ b/RTB/documenti_esterni/analisi_requisiti/include/requisiti.typ
@@ -95,7 +95,7 @@ I requisiti di vincolo rappresentano delle restrizioni o dei limiti che il siste
         table.header([*Codice*], [*Descrizione*], [*Fonti*]),
         align: horizon + center,
         [CMR 1],[Il prodotto deve prevedere almeno tre blocchi],[Capitolato],
-        [CDR 1], [Il prodotto deve essere sviluppato in container #glossario[Docker] così il deploy su vari ambienti cloud (ad esempio #glossario[AWS])], [Capitolato, Riunione col proponente],
+        [CDR 1], [Il prodotto deve essere sviluppato in container #glossario[Docker], facilitando così il rilascio su vari ambienti cloud (ad esempio #glossario[AWS])], [Capitolato, Riunione col proponente],
         [CMR 2],[Le parti del sistema devono comunicare tra di loro attraverso #glossario[API] che usano il protocollo HTTP],[Decisione interna]
     ),
     caption: [Tabella dei requisiti di vincolo.]

--- a/RTB/documenti_interni/glossario/glossario.typ
+++ b/RTB/documenti_interni/glossario/glossario.typ
@@ -9,6 +9,7 @@
   title: "Glossario",
   sommario: "Documento dei termini tecnici relativi al progetto.",
   changelog: (
+    "0.3.0", "Aggiunta definizione di Docker", team.T, ";_;",
     "0.2.0", "19/01/2025", "Aggiunti nuovi termini", team.T, team.G,
     "0.1.1", "20/12/2024", "Fix conformità indice di Gulpease", team.C, team.G,
     "0.1.0", "11/11/2024", "Prima versione", team.L, team.C
@@ -86,6 +87,9 @@ Metodo per visualizzare sistemi e software utilizzando il linguaggio di modellaz
 
 == Discord
 Piattaforma VoIP, messaggistica instantanea e distribuzione digitale.
+
+== Docker
+Piattaforma che permette di creare ambienti isolati di esecuzione chiamati container con un uso meno estensivo di risorse rispetto ad una macchina virtuale.
 
 = E
 


### PR DESCRIPTION
Gli altri requisiti, come ad esempio i linguaggi, le librerire e i framework da usare, verranno messi quando avremo prodotto un documento da riferire come fonte (Verbale interno o documento di specifica tecnica).
Ho spostato requisito di renderlo pronto per AWS e l'ho cambiato con Docker.

closes #191 
(Spero che il close funzioni perché l'ultima volta non andava)