### PR TITLE
Grafico metriche AC + ETC + EAC 

### DIFF
--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -36,8 +36,9 @@
     }), caption: caption)
 }
 
-#let sprint_number = 3
+// tot_spesa.at(i) => spesa sostenuta allo sprint i
 #let tot_spesa = ()
+#let sprint_number = 3
 #for i in range(1, sprint_number+1) {
     let (_, consuntivo) = getSprintCostsSection(sprint_number: i)
     let bilancio  = consuntivo.bilancioConsuntivo
@@ -50,17 +51,17 @@
 #linebreak()
 
 #let ac(offset: 0) = (
-         (1, tot_spesa.at(0)),
-         (2, tot_spesa.at(1)),
-         (3, tot_spesa.at(2)))
+         (1, tot_spesa.slice(0,1).sum()),
+         (2, tot_spesa.slice(0,2).sum()),
+         (3, tot_spesa.slice(0,3).sum()))
 #let etc(offset: 0) = (
          (1,12975 - tot_spesa.slice(0,1).sum()),
          (2,12975 - tot_spesa.slice(0,2).sum()),
          (3,12975 - tot_spesa.slice(0,3).sum()))
 #let eac(offset: 0) = (
-         (1, tot_spesa.at(0) + 12975 - tot_spesa.slice(0,1).sum()),
-         (2, tot_spesa.at(1) + 12975 - tot_spesa.slice(0,2).sum()),
-         (3, tot_spesa.at(2) + 12975 - tot_spesa.slice(0,3).sum()))  // eac = ac + etc
+         (1, tot_spesa.slice(0,1).sum() + 12975 - tot_spesa.slice(0,1).sum()),
+         (2, tot_spesa.slice(0,2).sum() + 12975 - tot_spesa.slice(0,2).sum()),
+         (3, tot_spesa.slice(0,3).sum() + 12975 - tot_spesa.slice(0,3).sum()))  // eac = ac + etc
 
 #lineChart(lines: (ac,etc,eac),
           legends: ([AC],[ETC],[EAC]),

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -77,4 +77,6 @@ Il grafico illustra:
 - #glossario[Estimated at Completion] (EAC): revisione del valore stimato per la realizzazione del progetto (AC + ETC).
 
 === RTB
-In questo periodo abbiamo un incremento di AC proporzionale al decremento di ETC. EAC resta invariato (= preventivo iniziale) però in futuro potrebbe abbassarsi.
+In questo periodo abbiamo un incremento di AC proporzionale al decremento di ETC. AC sta crescendo lentamente, questo perchè inizialmente le ore produttive sono molte meno rispetto a quelle di orologio.
+Inoltre in questo periodo erano presenti altri impegni importanti come le lezioni e gli esami.
+EAC resta invariato (= preventivo iniziale) però in futuro potrebbe abbassarsi.

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -71,4 +71,4 @@
 Il grafico illustra:
 - #glossario[Actual Cost]: i costi sostenuti fino ad ora;
 - #glossario[Estimate to Complete]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
-- #glossario[Estimated to Completion]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto.
+- #glossario[Estimated at Completion]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto.

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -1,2 +1,59 @@
 #import "/template/template.typ": glossario
+#import "@preview/cetz:0.3.1"
+#import "@preview/cetz-plot:0.1.0": plot, chart
+
+// lines   :: [[number], [number]]
+// legends :: [[content], [content]]
+// hlines  :: [number]
+#let lineChart(lines: array, legends: array, hlines: array, x-label: str, y-label: str, caption: content) = {
+    figure(
+    cetz.canvas({
+      plot.plot(size: (14,6),
+        legend: auto,
+        axis-style: "left",
+        x-label: [#pad(left: 35pt, top: 5pt, x-label)],
+        y-label: [#pad(right: 5pt, bottom: 5pt, y-label)],
+        x-tick-step: 1,
+        //y-tick-step: 0.5, {
+        {
+
+        for data in lines.zip(legends) {
+            plot.add(data.at(0)(offset: 0), line: "linear", label: data.at(1))
+        }
+
+        for hline in hlines {
+            plot.add-hline(hline, style:(stroke: (dash: "dashed", paint: gray)))
+        }
+      })
+    }), caption: caption)
+}
+
 = Cruscotto
+
+== Actual cost + Estimate to Complete + Estimated at Completion
+#linebreak()
+
+#let ac(offset: 0) = ((1,630),
+         (2,630 + 1135),
+         (3,630 + 1135 + 935),
+         (4,630 + 1135 + 935 + 660))
+#let etc(offset: 0) = ((1,12975),
+         (2,12975 - 1135),
+         (3,12975 - 1135 - 935),
+         (4,12975 - 1135 - 935 - 660))
+#let eac(offset: 0) = ((1,12975 + 630),
+         (2,12975 - 1135 + 630 + 1135),
+         (3,12975 - 1135 - 935 + 630 + 1135 + 935),
+         (4,12975 - 1135 - 935 - 660 + 630 + 1135 + 935 + 660)) // eac = ac + etc
+
+#lineChart(lines: (ac,etc,eac),
+          legends: ([AC],[ETC],[EAC]),
+          hlines: (),
+          x-label: "sprint",
+          y-label: "costo \u{20AC}",
+          caption: [AC + ETC + EAC])
+
+Il grafico illustra:
+- Actual Cost: i costi sostenuti fino ad ora;
+- Estimate to Complete: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
+- Estimated to Completion: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto.

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -72,4 +72,4 @@
 Il grafico illustra:
 - #glossario[Actual Cost]: i costi sostenuti fino ad ora;
 - #glossario[Estimate to Complete]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
-- #glossario[Estimated at Completion]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto.
+- #glossario[Estimated at Completion]: revisione del valore stimato per la realizzazione del progetto (AC + ETC).

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -2,6 +2,9 @@
 #import "@preview/cetz:0.3.1"
 #import "@preview/cetz-plot:0.1.0": plot, chart
 
+//#glossario[sprint]
+//#glossario[label]
+
 // lines   :: [[number], [number]]
 // legends :: [[content], [content]]
 // hlines  :: [number]
@@ -54,6 +57,6 @@
           caption: [AC + ETC + EAC])
 
 Il grafico illustra:
-- Actual Cost: i costi sostenuti fino ad ora;
-- Estimate to Complete: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
-- Estimated to Completion: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto.
+- #glossario[Actual Cost]: i costi sostenuti fino ad ora;
+- #glossario[Estimate to Complete]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
+- #glossario[Estimated to Completion]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto.

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -50,20 +50,21 @@
 == Actual cost + Estimate to Complete + Estimated at Completion
 #linebreak()
 
-#let ac(offset: 0) = (
-         (1, tot_spesa.slice(0,1).sum()),
-         (2, tot_spesa.slice(0,2).sum()),
-         (3, tot_spesa.slice(0,3).sum()))
-#let etc(offset: 0) = (
-         (1,12975 - tot_spesa.slice(0,1).sum()),
-         (2,12975 - tot_spesa.slice(0,2).sum()),
-         (3,12975 - tot_spesa.slice(0,3).sum()))
-#let eac(offset: 0) = (
-         (1, tot_spesa.slice(0,1).sum() + 12975 - tot_spesa.slice(0,1).sum()),
-         (2, tot_spesa.slice(0,2).sum() + 12975 - tot_spesa.slice(0,2).sum()),
-         (3, tot_spesa.slice(0,3).sum() + 12975 - tot_spesa.slice(0,3).sum()))  // eac = ac + etc
+#let ac = ()
+#let etc = ()
+#let eac = ()
+#let costo_totale_stimato = (12975, 12975, 12975)
+#for i in range(1, sprint_number+1) {
+    ac.push((i, tot_spesa.slice(0,i).sum()))
+    etc.push((i, costo_totale_stimato.at(i - 1) - tot_spesa.slice(0,i).sum()))
+    eac.push((i, costo_totale_stimato.at(i - 1)))
+}
 
-#lineChart(lines: (ac,etc,eac),
+#let ac_fun(offset: 0) = ac
+#let etc_fun(offset: 0) = etc
+#let eac_fun(offset: 0) = eac
+
+#lineChart(lines: (ac_fun,etc_fun,eac_fun),
           legends: ([AC],[ETC],[EAC]),
           hlines: (),
           x-label: "sprint",

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -7,6 +7,7 @@
 //#glossario[label]
 //#glossario[ac]
 //#glossario[etc]
+//#glossario[push]
 //#glossario[eac]
 
 // lines   :: [[number], [number]]

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -1,6 +1,7 @@
 #import "/template/template.typ": glossario
 #import "@preview/cetz:0.3.1"
 #import "@preview/cetz-plot:0.1.0": plot, chart
+#import "../../piano_progetto/include/costi.typ": getSprintCostsSection
 
 //#glossario[sprint]
 //#glossario[label]
@@ -34,23 +35,31 @@
     }), caption: caption)
 }
 
+#let sprint_number = 3
+#let tot_spesa = ()
+#for i in range(1, sprint_number+1) {
+    let (_, consuntivo) = getSprintCostsSection(sprint_number: i)
+    let bilancio  = consuntivo.bilancioConsuntivo
+    tot_spesa.push(12975 - tot_spesa.sum(default: 0) - bilancio)
+}
+
 = Cruscotto
 
 == Actual cost + Estimate to Complete + Estimated at Completion
 #linebreak()
 
-#let ac(offset: 0) = ((1,630),
-         (2,630 + 1135),
-         (3,630 + 1135 + 935),
-         (4,630 + 1135 + 935 + 660))
-#let etc(offset: 0) = ((1,12975),
-         (2,12975 - 1135),
-         (3,12975 - 1135 - 935),
-         (4,12975 - 1135 - 935 - 660))
-#let eac(offset: 0) = ((1,12975 + 630),
-         (2,12975 - 1135 + 630 + 1135),
-         (3,12975 - 1135 - 935 + 630 + 1135 + 935),
-         (4,12975 - 1135 - 935 - 660 + 630 + 1135 + 935 + 660)) // eac = ac + etc
+#let ac(offset: 0) = (
+         (1, tot_spesa.at(0)),
+         (2, tot_spesa.at(1)),
+         (3, tot_spesa.at(2)))
+#let etc(offset: 0) = (
+         (1,12975 - tot_spesa.slice(0,1).sum()),
+         (2,12975 - tot_spesa.slice(0,2).sum()),
+         (3,12975 - tot_spesa.slice(0,3).sum()))
+#let eac(offset: 0) = (
+         (1, tot_spesa.at(0) + 12975 - tot_spesa.slice(0,1).sum()),
+         (2, tot_spesa.at(1) + 12975 - tot_spesa.slice(0,2).sum()),
+         (3, tot_spesa.at(2) + 12975 - tot_spesa.slice(0,3).sum()))  // eac = ac + etc
 
 #lineChart(lines: (ac,etc,eac),
           legends: ([AC],[ETC],[EAC]),

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -46,8 +46,7 @@
 }
 
 = Cruscotto
-
-== Actual cost + Estimate to Complete + Estimated at Completion
+== MPRO1 (AC), MPRO8 (ETC), MPRO7 (EAC)
 #linebreak()
 
 #let ac = ()
@@ -69,7 +68,7 @@
           hlines: (),
           x-label: "sprint",
           y-label: "costo \u{20AC}",
-          caption: [AC + ETC + EAC])
+          caption: [AC, ETC, EAC])
 
 Il grafico illustra:
 - #glossario[Actual Cost] (AC): i costi sostenuti fino ad ora;

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -75,3 +75,6 @@ Il grafico illustra:
 - #glossario[Actual Cost] (AC): i costi sostenuti fino ad ora;
 - #glossario[Estimate to Complete] (ETC): il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
 - #glossario[Estimated at Completion] (EAC): revisione del valore stimato per la realizzazione del progetto (AC + ETC).
+
+=== RTB
+In questo periodo abbiamo un incremento di AC proporzionale al decremento di ETC. EAC resta invariato (= preventivo iniziale) però in futuro potrebbe abbassarsi.

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -72,6 +72,6 @@
           caption: [AC + ETC + EAC])
 
 Il grafico illustra:
-- #glossario[Actual Cost]: i costi sostenuti fino ad ora;
-- #glossario[Estimate to Complete]: il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
-- #glossario[Estimated at Completion]: revisione del valore stimato per la realizzazione del progetto (AC + ETC).
+- #glossario[Actual Cost] (AC): i costi sostenuti fino ad ora;
+- #glossario[Estimate to Complete] (ETC): il valore stimato per la realizzazione delle rimanenti attività necessarie al completamento del progetto;
+- #glossario[Estimated at Completion] (EAC): revisione del valore stimato per la realizzazione del progetto (AC + ETC).

--- a/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/controllo-metriche.typ
@@ -4,6 +4,9 @@
 
 //#glossario[sprint]
 //#glossario[label]
+//#glossario[ac]
+//#glossario[etc]
+//#glossario[eac]
 
 // lines   :: [[number], [number]]
 // legends :: [[content], [content]]

--- a/RTB/documenti_esterni/piano_qualifica/include/definizione-metriche.typ
+++ b/RTB/documenti_esterni/piano_qualifica/include/definizione-metriche.typ
@@ -1,5 +1,8 @@
 #import "/template/template.typ": glossario
 
+// WARNING: aggiungere le nuove metriche con il push solo alla fine. Altrimenti potrebbe cambiare l'ordine degli indici e nel cruscotto viene fuori un macello.
+// Se si rimuovono delle metriche bisogna controllare i codici all'interno del cruscotto.
+
 #let getMPRO(number) = {
     let MPRO = ()
 

--- a/RTB/documenti_esterni/piano_qualifica/piano-di-qualifica.typ
+++ b/RTB/documenti_esterni/piano_qualifica/piano-di-qualifica.typ
@@ -4,6 +4,7 @@
   title: "Piano di qualifica",
   sommario: "Il documento espone le metriche di verifica attuate per garantire qualità.",
   changelog: (
+    "0.6.0", "06/02/2025", "Aggiunto grafico metriche AC, ETC, EAC", team.G, team.T,
     "0.5.4", "05/02/2025", "Modifica metriche qualità di processo", team.S, team.M,
     "0.5.3", "05/02/2025", "Modifica tabella metriche pianificazione e miglioramento", team.A, team.T,
     "0.5.2", "05/02/2025", "Fix caption tabelle", team.G, team.T,


### PR DESCRIPTION
Ho messo i direttamente i valori, non so se possa essere utile fare un refactoring di costi in pdq in modo da riprendersi i dati da lì.

EDIT: Non è servito cambiare costi di pdp perchè la funzione ritorna il valore di bilancio ad ogni sprint e da quella calcolo i costi sostenuti ad ogni sprint (salvati nella variabile tot_spesa).

close #254
close #255
close #256