### PR TITLE
Piccoli fix ndp

### DIFF
--- a/RTB/documenti_interni/norme_progetto/include/processi-di-supporto.typ
+++ b/RTB/documenti_interni/norme_progetto/include/processi-di-supporto.typ
@@ -19,8 +19,8 @@ Per la natura di questo progetto, la prima e ultima attività non verranno svolt
 === Progettazione e sviluppo
 ==== Filosofia "Docs as code" <docsascode>
 Abbiamo scelto di usare la filosofia "Docs as code" che si prescrive di trattare tutta la documentazione come se fosse del vero e proprio codice sorgente. \ Questo porta i seguenti vantaggi:
-+ Supporto agli #glossario[issue tracking system];;
-+ Controllo di versione con #glossario[git];;
++ Supporto agli #glossario[issue tracking system]\;
++ Controllo di versione con #glossario[git]\;
 + Processi di revisione del codice;
 + Test e #glossario[integrazione continua].
 

--- a/RTB/documenti_interni/norme_progetto/include/processi-organizzativi.typ
+++ b/RTB/documenti_interni/norme_progetto/include/processi-organizzativi.typ
@@ -66,7 +66,7 @@ In particolare:
     - definisce i tempi e i costi;
     - redige piani dettagliati da inserire nel piano di progetto.
 - Verifica la fattibilità del piano proposto;
-- Gestisce le relazioni con gli altri #glossario[stakeholder] ;
+- Gestisce le relazioni con gli altri #glossario[stakeholder]#h(1pt)\;
 - Controlla i progressi del progetto;
 - Gestisce il bilancio.
 
@@ -92,7 +92,7 @@ Partendo dal lavoro dell'analista effettua scelte progettuali per definire il "c
 Scrive il codice software con l'obiettivo che esso rispecchi i requisiti individuati con l'analisi e le specifiche fornite dai progettisti. 
 
 Il codice scritto deve:
-- Contenere gli strumenti per la verifica e la #glossario[validazione] ;
+- Contenere gli strumenti per la verifica e la #glossario[validazione]\;
 - Rispecchiare l'architettura ideata dai progettisti;
 - Essere conforme ai requisiti di qualità stabiliti.
 

--- a/RTB/documenti_interni/norme_progetto/include/processi-primari.typ
+++ b/RTB/documenti_interni/norme_progetto/include/processi-primari.typ
@@ -3,13 +3,7 @@
 #import fletcher.shapes: ellipse, rect
 #import "@preview/cetz:0.3.0"
 #import cetz.draw
-
-#let empty-dash = (
-    inherit: "}>",
-    size: 10,
-    fill: none,
-    stealth: 0
-)
+#import "/RTB/documenti_esterni/analisi_requisiti/include/use_cases.typ": empty-dash, uc_comment
 
 = Processi primari
 Un progetto è definito tale se e solo se in esso sono attivi processi primari. 
@@ -22,7 +16,7 @@ Lo standard, all'interno dei processi primari, definisce 5 categorie:
 3. Sviluppo;
 4. Gestione operativa;
 5. Manutenzione.
-I processi di acquisizione e manutenzione non saranno descritti a causa della natura di questo progetto.
+I processi di acquisizione, manutenzione e gestione operativa non saranno descritti a causa della natura di questo progetto.
 
 == Fornitura
 === Scopo 
@@ -84,7 +78,7 @@ L'attività di analisi dei requisiti è fondamentale per:
 - La corretta comprensione delle esigenze del proponente;
 - Identificare, documentare e validare i requisiti funzionali e non funzionali;
 - Evitare il rischio che il prodotto software non converga mai verso le aspettative del proponente;
-- Facilitare la compresione dei requisiti a tutti gli #glossario[stakeholder] ;
+- Facilitare la compresione dei requisiti a tutti gli #glossario[stakeholder]#h(1pt)\;
 - Garantire che la progettazione riceva dei requisiti chiari e semplici da comprendere.
 
 In questa fase il nostro compito è quindi quello di raccogliere, analizzare e documentare i requisiti del prodotto (requisiti software).
@@ -222,7 +216,7 @@ I componenti principali di un diagramma dei casi d'uso sono:
 
         node((3,0.5), align(center)[UC.b Nome], name: <euc>),
 
-        node((2.3,1), align(center)[Condizione di estensione], name: <cond>, shape: rect),
+        node((2.3,1), align(center)[Condizione di estensione], name: <cond>, shape: uc_comment),
 
         node((2.3, 0.5), align(center)[], name: <coll>, width: 1pt, height: 1pt),
         edge(<coll>, <cond>, "--"),
@@ -272,7 +266,7 @@ Ogni requisito è costituito da:
 
 #h(3%)"Importanza" corrisponde a:
 
-#list(["M", mandatory, requisito obbligatorio, irrinunciabile per qualcuno degli #glossario[stakeholder] ;],["D", desirable, requisito desiderabile, non strettamente necessario ma a valore aggiunto riconoscibile;],["O", optional, requisito opzionale, relativamente utile e contrattabile anche quando il progetto è in uno stato avanzato;],indent: 2.5em)
+#list(["M", mandatory, requisito obbligatorio, irrinunciabile per qualcuno degli #glossario[stakeholder]#h(1pt)\;],["D", desirable, requisito desiderabile, non strettamente necessario ma a valore aggiunto riconoscibile;],["O", optional, requisito opzionale, relativamente utile e contrattabile anche quando il progetto è in uno stato avanzato;],indent: 2.5em)
 #h(3%)"N" è un numero progressivo (es. QMR2 indica un requisito di qualità obbligatorio numero 2);
 
 2. Descrizione: una breve descrizione del requisito;

--- a/RTB/documenti_interni/norme_progetto/include/processi-primari.typ
+++ b/RTB/documenti_interni/norme_progetto/include/processi-primari.typ
@@ -78,7 +78,7 @@ L'attività di analisi dei requisiti è fondamentale per:
 - La corretta comprensione delle esigenze del proponente;
 - Identificare, documentare e validare i requisiti funzionali e non funzionali;
 - Evitare il rischio che il prodotto software non converga mai verso le aspettative del proponente;
-- Facilitare la compresione dei requisiti a tutti gli #glossario[stakeholder]#h(1pt)\;
+- Facilitare la comprensione dei requisiti a tutti gli #glossario[stakeholder]#h(1pt)\;
 - Garantire che la progettazione riceva dei requisiti chiari e semplici da comprendere.
 
 In questa fase il nostro compito è quindi quello di raccogliere, analizzare e documentare i requisiti del prodotto (requisiti software).

--- a/RTB/documenti_interni/norme_progetto/norme-di-progetto.typ
+++ b/RTB/documenti_interni/norme_progetto/norme-di-progetto.typ
@@ -9,6 +9,7 @@
   title: "Norme di progetto",
   sommario: "Documento che descrive le norme di progetto del gruppo Tech Minds.",
   changelog: (
+    "0.11.1", "12/02/2025", "Fix grafici termini glossario e UML", team.G, "",
     "0.11.0", "11/02/2025", "Descritto il sito web, diagramma di Gantt", team.G, team.M,
     "0.10.0", "11/02/2025", "Gestione link e fix issue", team.C, team.T,
     "0.9.1", "10/02/2025", "Piccoli fix", team.S, team.T,

--- a/RTB/documenti_interni/norme_progetto/norme-di-progetto.typ
+++ b/RTB/documenti_interni/norme_progetto/norme-di-progetto.typ
@@ -9,7 +9,7 @@
   title: "Norme di progetto",
   sommario: "Documento che descrive le norme di progetto del gruppo Tech Minds.",
   changelog: (
-    "0.11.1", "12/02/2025", "Fix grafici termini glossario e UML", team.G, "",
+    "1.0.0", "12/02/2025", "Fix grafici termini glossario e UML", team.G, team.M,
     "0.11.0", "11/02/2025", "Descritto il sito web, diagramma di Gantt", team.G, team.M,
     "0.10.0", "11/02/2025", "Gestione link e fix issue", team.C, team.T,
     "0.9.1", "10/02/2025", "Piccoli fix", team.S, team.T,


### PR DESCRIPTION
- In **norme di progetto (pagina 7)**
Dopo l'elento dei processi primari è stato scritto ciò
`I processi di acquisizione e manutenzione non saranno descritti a causa della natura di questo progetto.`
però noi in realtà non faremo nemmeno la gestione operativa.

- In **norme di progetto (pagina 11)**
Il commento degli UC non è aggiornato (manca la piegatura).

- Da qualche parte capita che quando la parola di glossario ha un punto e virgola alla fine c'è uno spazio fra i due.