### PR TITLE
Tolta verbosità check glossario CI

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -22,7 +22,7 @@ jobs:
         tar xf typst*.tar.xz -C /tmp
         sudo mv /tmp/typst*/typst /bin/typst
     - name: Check Glossario
-      run: python .github/workflows/check_glossario.py
+      run: python .github/workflows/check_glossario.py > /dev/null
     - name: Indice di Gulpease
       run: python .github/workflows/indice_gulpease.py
     - name: Check ordinamento glossario

--- a/.github/workflows/check_glossario.py
+++ b/.github/workflows/check_glossario.py
@@ -49,8 +49,8 @@ def check_single_term(termine, text):
 
 # Controllo dei termini nel file
 def check(f, text, termini_glossario, termini_contenuti):
-    print("-----------------------------")
-    print("Searching terms in {}".format(f))
+    print("-----------------------------", file=sys.stderr)
+    print("Searching terms in {}".format(f), file=sys.stderr)
     return_value = 0
     for termine in termini_glossario:
         if len(termine) == 1:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -16,7 +16,7 @@ jobs:
         tar xf typst*.tar.xz -C /tmp
         sudo mv /tmp/typst*/typst /bin/typst
     - name: Check Glossario
-      run: python .github/workflows/check_glossario.py
+      run: python .github/workflows/check_glossario.py > /dev/null
     - name: Indice di Gulpease
       run: python .github/workflows/indice_gulpease.py
     - name: Check ordinamento glossario

--- a/PB/documenti_interni/norme_progetto/include/processi-di-supporto.typ
+++ b/PB/documenti_interni/norme_progetto/include/processi-di-supporto.typ
@@ -165,7 +165,7 @@ dove:
 Il cruscotto è realizzato usando Typst. Ogni volta che viene compilato, il documento riprende tutti i valori aggiornati degli sprint da una funzione apposita (definita in costi.typ nella directory contenente il piano di progetto).
 I valori ottenuti vengono usati per calcolare le varie metriche, che saranno successivamente visualizzate attraverso dei grafici, sempre generati in Typst con la libreria CeTZ.
 C'è da precisare che questa è una procedura semi-automatica, ad esempio alcuni dati per le metriche devono essere inseriti a mano ad ogni sprint.
-I dati in questione riguardano l'indice di Gulpease, rischi non previsti e l'Earned Value.
+I dati in questione riguardano l'indice di Gulpease, rischi non previsti e l'#glossario[Earned Value].
 
 === Strumenti e tecnologie
 Il team ha deciso di utilizzare Typst per la redazione del piano di qualifica e per la generazione e la gestione del cruscotto in esso contenuto.

--- a/PB/documenti_interni/norme_progetto/include/processi-di-supporto.typ
+++ b/PB/documenti_interni/norme_progetto/include/processi-di-supporto.typ
@@ -165,7 +165,7 @@ dove:
 Il cruscotto è realizzato usando Typst. Ogni volta che viene compilato, il documento riprende tutti i valori aggiornati degli sprint da una funzione apposita (definita in costi.typ nella directory contenente il piano di progetto).
 I valori ottenuti vengono usati per calcolare le varie metriche, che saranno successivamente visualizzate attraverso dei grafici, sempre generati in Typst con la libreria CeTZ.
 C'è da precisare che questa è una procedura semi-automatica, ad esempio alcuni dati per le metriche devono essere inseriti a mano ad ogni sprint.
-I dati in questione riguardano l'indice di Gulpease, rischi non previsti e l'#glossario[Earned Value].
+I dati in questione riguardano l'indice di Gulpease, rischi non previsti e l'Earned Value.
 
 === Strumenti e tecnologie
 Il team ha deciso di utilizzare Typst per la redazione del piano di qualifica e per la generazione e la gestione del cruscotto in esso contenuto.


### PR DESCRIPTION
Quando la build fallisce per il glossario, si perde sempre troppo tempo a trovare l'errore perchè è sempre sommerso dagli OK.
Questa modifica fa in modo che venga stampato in output sulla console solo quello che viene stampato in `stderr`, ovvero gli errori.

Per testarlo provate in locale ad eseguire python check_glossario.py > `/dev/null` togliendo un termine del glossario