### PR TITLE
Modificate metriche qualità di prodotto pdq

### DIFF
--- a/PB/documenti_esterni/piano_qualifica/include/definizione-metriche.typ
+++ b/PB/documenti_esterni/piano_qualifica/include/definizione-metriche.typ
@@ -274,8 +274,8 @@
             "manutenibilità"))
 
 #MPROD.push(  ("MPROD" + str(MPROD.len()+1),
-            [Numero di dichiarazioni per funzione],
-            [Misura il massimo numero di dichiarazioni in una funzione.],
+            [Numero di variabili dichiarate per funzione],
+            [Misura il massimo numero di dichiarazioni di variabili in una funzione.],
             [Numero dichiarazioni = Numero di dichiarazioni per funzione;],
             [\u{2A7D}8],
             [\u{2A7D}5],

--- a/PB/documenti_esterni/piano_qualifica/include/definizione-metriche.typ
+++ b/PB/documenti_esterni/piano_qualifica/include/definizione-metriche.typ
@@ -252,25 +252,33 @@
 #MPROD.push(  ("MPROD" + str(MPROD.len()+1),
             [Linee di codice per metodo],
             [Numero massimo di linee di codice per metodo.],
-            [Linee di codice per metodo =  Numero di linee di codice del metodo in esame;],
+            [Linee di codice per metodo = Numero di linee di codice del metodo in esame;],
             [\u{2A7D}30],
             [\u{2A7D}20],
             "manutenibilità"))
 
 #MPROD.push(  ("MPROD" + str(MPROD.len()+1),
-            [Attributi per classe],
-            [Numero massimo di attributi per classe.],
-            [Attributi per classe = Numero di attributi di una classe;],
+            [Linee di codice per file],
+            [Numero massimo di linee di codice per file.],
+            [Linee di codice per file = Numero di linee di codice del file in esame;],
+            [\u{2A7D}300],
+            [\u{2A7D}200],
+            "manutenibilità"))
+
+#MPROD.push(  ("MPROD" + str(MPROD.len()+1),
+            [Profondità blocchi di codice innestati],
+            [Misura la profondità massima di blocchi di codice innestati.],
+            [Profondità massima = Numero di livelli innestati tra il blocco più esterno e quello più interno;],
             [\u{2A7D}4],
             [\u{2A7D}3],
             "manutenibilità"))
 
 #MPROD.push(  ("MPROD" + str(MPROD.len()+1),
-            [Profondità della gerarchie],
-            [Metrica che misura il numero di livelli tra una classe base (superclasse) e le sue sottoclassi (classi derivate).],
-            [$"Profondità della gerarchie" &= max("livelli tra una classe e la sua radice nella gerarchia")$;],
+            [Numero di dichiarazioni per funzione],
+            [Misura il massimo numero di dichiarazioni in una funzione.],
+            [Numero dichiarazioni = Numero di dichiarazioni per funzione;],
+            [\u{2A7D}8],
             [\u{2A7D}5],
-            [\u{2A7D}3],
             "manutenibilità"))
 
 #MPROD.push(  ("MPROD" + str(MPROD.len()+1),

--- a/PB/documenti_esterni/piano_qualifica/piano-di-qualifica.typ
+++ b/PB/documenti_esterni/piano_qualifica/piano-di-qualifica.typ
@@ -4,7 +4,7 @@
   title: "Piano di qualifica",
   sommario: "Il documento riporta le attività di verifica e validazione, affidandosi a delle metriche per garantire la qualità del prodotto.",
   changelog: (
-    "1.4.2", "06/03/2025", "Modifica metriche qualità per prodotto", team.S, "",
+    "1.4.2", "06/03/2025", "Modifica metriche qualità di prodotto", team.S, team.A,
     "1.4.1", "04/03/2025", "Correzione uso del termine \"fase\"", team.L, team.C,
     "1.4.0", "03/03/2025", "Aggiunta test di accettazione", team.C, team.A,
     "1.3.0", "03/03/2025", "Aggiunta miglioramento", team.C, team.A,

--- a/PB/documenti_esterni/piano_qualifica/piano-di-qualifica.typ
+++ b/PB/documenti_esterni/piano_qualifica/piano-di-qualifica.typ
@@ -4,6 +4,7 @@
   title: "Piano di qualifica",
   sommario: "Il documento riporta le attività di verifica e validazione, affidandosi a delle metriche per garantire la qualità del prodotto.",
   changelog: (
+    "1.4.2", "06/03/2025", "Modifica metriche qualità per prodotto", team.S, "",
     "1.4.1", "04/03/2025", "Correzione uso del termine \"fase\"", team.L, team.C,
     "1.4.0", "03/03/2025", "Aggiunta test di accettazione", team.C, team.A,
     "1.3.0", "03/03/2025", "Aggiunta miglioramento", team.C, team.A,


### PR DESCRIPTION
nel changelog c'è da cambiare il "per" in "di", abbiamo cambiato alcune metriche considerando l'analisi statica implementata.